### PR TITLE
gulp clean up + improvements

### DIFF
--- a/STARTERKIT/components/_init.scss
+++ b/STARTERKIT/components/_init.scss
@@ -25,8 +25,8 @@
 
 // The following Sass functions/mixins are required to generate some variables'
 // values, so we load them first.
-@import 'breakpoint';
-@import 'chroma/functions';
+@import 'breakpoint-sass';
+@import 'chroma-sass/sass/chroma/_functions.scss';
 
 @import 'init/colors';
 @import 'init/variables';
@@ -46,8 +46,8 @@
 // Style guide: sass.modules
 
 // Add Chroma to manage colors.
-@import 'chroma';
-@import 'chroma/kss';
+@import 'chroma-sass';
+@import 'chroma-sass/sass/chroma/_kss.scss';
 // Add support-for to manage normalize-scss' browser support.
 @import 'support-for';
 // Add typey to manage font sizes and margins.


### PR DESCRIPTION
Following up the issue #4, list of changes:

-------

### Proper import resolvers

Now imports are based on node package module name, so Instead of

```js
// Define the node-sass configuration. The includePaths is critical!
options.sass = {
  importer: importOnce,
  includePaths: [
    options.theme.components,
    options.rootPath.project + 'node_modules/breakpoint-sass/stylesheets',
    options.rootPath.project + 'node_modules/chroma-sass/sass',
    options.rootPath.project + 'node_modules/support-for/sass',
    options.rootPath.project + 'node_modules/typey/stylesheets',
    options.rootPath.project + 'node_modules/zen-grids/sass'
  ],
  outputStyle: 'expanded'
};
```

We now have:

```js
function sassModuleImporter(url, file, done) {
  try {
    let pathResolution = require.resolve(url);
    return done({ file: pathResolution });
  }
  catch (e) {
    return null;
  }
}

// Define the node-sass configuration. The includePaths is critical!
options.sass = {
  importer: [sassModuleImporter, importOnce],
  includePaths: options.theme.components,
  outputStyle: 'expanded'
};
```

### Repeated tasks and environment management

`styles:production` has been removed and an environment variable has been added `NODE_ENV` which can have the value of `production`, `development` and `testing` for CI. No need for extra tasks for the linters anymore.

for the same reason, `lint:js-with-fail` and `lint:sass-with-fail` are no longer needed and will fail on errors when `NODE_ENV=testing` 

-------------

### For Testing

1- Start with a fresh Drupal

2- Clone the repo with this changes: github.com/pabloguerino/zen and checkout to 'gulp-clean-up' and then install new theme from starterkit

3- adjust environment

* For live/production, you will get minified assets
* For testing, the linters will return an exit code of 1 (you can check the returned code with `$?`)
* For development, you will get source maps and expanded/uncompressed js/css

to handle the environment change, we will use the `NODE_ENV` variable (which is what most webpack/gulp setups uses), so by following that we can use the different environments like this:

* `NODE_ENV=production gulp` for minified assets
* `NODE_ENV=testing gulp` linters with change error code
* `gulp` or `NODE_ENV=development gulp` anything that can help while developing

4- where to check the changes

I suggest that we move everything to a `dist` folder, but for now, we are keeping what we already have. So we have css in ` components/asset-builds/css/` and all other on `dist`