### PR TITLE
Removing Zen dependencies for starterkit

### DIFF
--- a/STARTERKIT/STARTERKIT.info.yml
+++ b/STARTERKIT/STARTERKIT.info.yml
@@ -23,8 +23,7 @@ screenshot: screenshot.png
 core: 8.x
 type: theme
 # Classy vs. Stable as a base theme: https://www.lullabot.com/articles/a-tale-of-two-base-themes-in-drupal-8-core
-# Zen uses classy as its base theme.
-base theme: zen
+base theme: classy
 
 
 

--- a/STARTERKIT/STARTERKIT.theme
+++ b/STARTERKIT/STARTERKIT.theme
@@ -8,6 +8,82 @@
  */
 
 
+// Auto-rebuild the theme registry during theme development.
+if (theme_get_setting('zen_rebuild_registry') && !defined('MAINTENANCE_MODE')) {
+  // Rebuild .info.yml data and clear Twig cache.
+  $theme_handler = \Drupal::service('theme_handler');
+  $theme_handler->refreshInfo();
+
+  // Rebuild theme registry.
+  // @TODO Clear the theme registry.
+  // $theme_registry = \Drupal::service('theme.registry');
+  // $theme_registry->reset();
+  // $theme_registry->get();
+
+  // @TODO: Turn on Twig debugging. Though its probably impossible from a theme.
+  // $GLOBALS['conf']['theme_debug'] = TRUE;
+}
+
+/**
+ * Implements HOOK_theme().
+ */
+function STARTERKIT_theme(&$existing, $type, $theme, $path) {
+  include_once './' . drupal_get_path('theme', 'STARTERKIT') . '/include/theme-registry.inc';
+  return _zen_theme($existing, $type, $theme, $path);
+}
+
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function STARTERKIT_theme_suggestions_page_alter(array &$suggestions, array $variables) {
+  // If on an individual node page, add the node type to theme suggestions.
+  if ($node = \Drupal::routeMatch()->getParameter('node')) {
+    $first_suggestion = array_shift($suggestions);
+    array_unshift($suggestions, 'page__node__' . $node->bundle());
+    if ($first_suggestion) {
+      array_unshift($suggestions, $first_suggestion);
+    }
+    if (in_array('page__node__edit', $suggestions)) {
+      $suggestions[] = 'page__node__edit__' . $node->bundle();
+    }
+  }
+}
+
+/**
+ * Implements hook_pre_render_HOOK() for menu-local-tasks templates.
+ *
+ * Use preprocess hook to convert menu_local_task into variables needed by the
+ * tabs component.
+ */
+function STARTERKIT_preprocess_menu_local_tasks(&$variables) {
+  foreach (array('primary', 'secondary') as $type) {
+    $tabs = array();
+
+    // Sort the tabs by #weight.
+    uasort($variables[$type], array('Drupal\Component\Utility\SortArray', 'sortByWeightProperty'));
+
+    foreach (array_keys($variables[$type]) as $key) {
+      // Add the tab to a new array.
+      $tabs[$key] = array(
+        'active' => $variables[$type][$key]['#active'],
+        'url' => $variables[$type][$key]['#link']['url']->toString(),
+        'text' => \Drupal\Component\Utility\Html::escape($variables[$type][$key]['#link']['title'])
+      );
+
+      // Check if the tab should be shown by rendering the original.
+      $link = drupal_render($variables[$type][$key]);
+      if (!$link) {
+        unset($tabs[$key]);
+      }
+    }
+
+    // Overwrite the original tabs data.
+    $variables[$type] = $tabs;
+  }
+}
+
+
 /**
  * Override or insert variables into the maintenance page template.
  *

--- a/STARTERKIT/include/theme-registry.inc
+++ b/STARTERKIT/include/theme-registry.inc
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @file
+ * Contains infrequently used theme registry build functions.
+ */
+
+/**
+ * Implements HOOK_theme().
+ *
+ * We are simply using this hook as a convenient time to do some related work.
+ */
+function _zen_theme(&$existing, $type, $theme, $path) {
+  // If we are auto-rebuilding the theme registry, warn about the feature.
+  $active_theme = \Drupal::theme()->getActiveTheme()->getName();
+  $flood_name = $active_theme . '.rebuild_registry_warning';
+  $is_admin_route = \Drupal::service('router.admin_context')->isAdminRoute(\Drupal::routeMatch()->getRouteObject());
+  if (
+    // Don't display on update.php or install.php.
+    !defined('MAINTENANCE_MODE')
+    // Only display for theme admins.
+    && \Drupal::currentUser()->hasPermission('administer themes')
+    && theme_get_setting('zen_rebuild_registry')
+    // Always display in the admin section, otherwise limit to three per hour.
+    && ($is_admin_route || \Drupal::flood()->isAllowed($flood_name, 3))
+  ) {
+    \Drupal::flood()->register($flood_name);
+    drupal_set_message(t('For easier theme development, the theme registry is being rebuilt on every page request. It is <em>extremely</em> important to <a href="!link">turn off this feature</a> on production websites.', array('!link' => url('admin/appearance/settings/' . $active_theme))), 'warning', FALSE);
+  }
+
+  // hook_theme() expects an array, so return an empty one.
+  return array();
+}

--- a/STARTERKIT/include/theme-registry.inc
+++ b/STARTERKIT/include/theme-registry.inc
@@ -4,6 +4,8 @@
  * Contains infrequently used theme registry build functions.
  */
 
+use Drupal\Core\Url;
+
 /**
  * Implements HOOK_theme().
  *
@@ -24,7 +26,9 @@ function _zen_theme(&$existing, $type, $theme, $path) {
     && ($is_admin_route || \Drupal::flood()->isAllowed($flood_name, 3))
   ) {
     \Drupal::flood()->register($flood_name);
-    drupal_set_message(t('For easier theme development, the theme registry is being rebuilt on every page request. It is <em>extremely</em> important to <a href="!link">turn off this feature</a> on production websites.', array('!link' => url('admin/appearance/settings/' . $active_theme))), 'warning', FALSE);
+    drupal_set_message(t('For easier theme development, the theme registry is being rebuilt on every page request. It is <em>extremely</em> important to <a href="@link">turn off this feature</a> on production websites.', [
+      '@link' => Url::fromRoute('system.theme_settings_theme', ['theme' => $active_theme])->toString(),
+    ]), 'warning', FALSE);
   }
 
   // hook_theme() expects an array, so return an empty one.

--- a/STARTERKIT/theme-settings.php
+++ b/STARTERKIT/theme-settings.php
@@ -21,6 +21,6 @@ function STARTERKIT_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\F
     '#type'          => 'checkbox',
     '#title'         => t('Rebuild theme registry and output template debugging on every page.'),
     '#default_value' => theme_get_setting('zen_rebuild_registry'),
-    '#description'   => t('During theme development, it can be very useful to continuously <a href="!link">rebuild the theme registry</a> and to output template debugging HTML comments. WARNING: this is a huge performance penalty and must be turned off on production websites.', array('!link' => 'https://drupal.org/node/173880#theme-registry')),
+    '#description'   => t('During theme development, it can be very useful to continuously <a href="@link">rebuild the theme registry</a> and to output template debugging HTML comments. WARNING: this is a huge performance penalty and must be turned off on production websites.', array('@link' => 'https://drupal.org/node/173880#theme-registry')),
   );
 }

--- a/STARTERKIT/theme-settings.php
+++ b/STARTERKIT/theme-settings.php
@@ -13,21 +13,14 @@ function STARTERKIT_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\F
     return;
   }
 
-  // Create the form using Forms API: http://api.drupal.org/api/7
-
-  /* -- Delete this line if you want to use this setting
-  $form['STARTERKIT_example'] = array(
-  '#type'          => 'checkbox',
-  '#title'         => t('STARTERKIT sample setting'),
-  '#default_value' => theme_get_setting('STARTERKIT_example'),
-  '#description'   => t("This example option doesn't do anything."),
+  $form['themedev'] = array(
+    '#type'          => 'fieldset',
+    '#title'         => t('Theme development settings'),
   );
-  // */
-
-  /* -- Delete this line if you want to remove this base theme setting.
-  // We don't need breadcrumbs to be configurable on this site.
-  unset($form['breadcrumb']);
-  // */
-
-  // We are editing the $form in place, so we don't need to return anything.
+  $form['themedev']['zen_rebuild_registry'] = array(
+    '#type'          => 'checkbox',
+    '#title'         => t('Rebuild theme registry and output template debugging on every page.'),
+    '#default_value' => theme_get_setting('zen_rebuild_registry'),
+    '#description'   => t('During theme development, it can be very useful to continuously <a href="!link">rebuild the theme registry</a> and to output template debugging HTML comments. WARNING: this is a huge performance penalty and must be turned off on production websites.', array('!link' => 'https://drupal.org/node/173880#theme-registry')),
+  );
 }


### PR DESCRIPTION
Solution for #8 

How to check:
* install fresh drupal
* `cd themes`
* `git clone git@github.com:skilld-labs/zen.git && cd zen && git checkout issue8-remove-zen-dependencies`
* `drush en components -y`
* `drush en  zen -y`
* `drush zen test_starterkit`
* `drush en test_starterkit -y`
* `drush config-set system.theme default test_starterkit -y` 
* `rm -rf themes/zen`
* `drush cr`
Then open site front page
You should see enabled and worked starterkit theme