### PR TITLE
Fix code styles

### DIFF
--- a/STARTERKIT/README.txt
+++ b/STARTERKIT/README.txt
@@ -61,7 +61,10 @@ CREATING A SUB-THEME WITH DRUSH
     * Use:  drush zen zomg_amazing "Amazing name"
       to create a sub-theme named "Amazing name" with a machine name of
       zomg_amazing, using the default options.
-    * Use:  drush zen "Amazing name" --path=sites/default/themes --description="So amazing."
+    * Use:
+      drush zen "Amazing name" \
+        --path=sites/default/themes \
+        --description="So amazing."
       to create a sub-theme in the specified directory with a custom
       description.
 
@@ -183,10 +186,11 @@ Set up your front-end development build tools:
     To better understand the recommended development process for your Zen
     sub-theme, watch the Drupalcon presentation, "Style Guide Driven
     Development: All hail the robot overlords!"
-    https://events.drupal.org/losangeles2015/sessions/style-guide-driven-development-all-hail-robot-overlords
+    https://youtu.be/y5coJloNutU
 
- 6. The environment can be adjusted by using the NODE_ENV variable, the available environments
-    are 'production', 'testing' and 'development'. This last one is the default.
+ 6. The environment can be adjusted by using the NODE_ENV variable, the
+    available environments are 'production', 'testing' and 'development'.
+    This last one is the default.
 
       # production: for minified assets
       NODE_ENV=production gulp

--- a/STARTERKIT/STARTERKIT.theme
+++ b/STARTERKIT/STARTERKIT.theme
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Contains the theme's functions to manipulate Drupal's default markup.
@@ -7,31 +8,22 @@
  * @see https://drupal.org/node/1728096
  */
 
+use Drupal\Component\Utility\Html;
 
 // Auto-rebuild the theme registry during theme development.
 if (theme_get_setting('zen_rebuild_registry') && !defined('MAINTENANCE_MODE')) {
   // Rebuild .info.yml data and clear Twig cache.
   $theme_handler = \Drupal::service('theme_handler');
   $theme_handler->refreshInfo();
-
-  // Rebuild theme registry.
-  // @TODO Clear the theme registry.
-  // $theme_registry = \Drupal::service('theme.registry');
-  // $theme_registry->reset();
-  // $theme_registry->get();
-
-  // @TODO: Turn on Twig debugging. Though its probably impossible from a theme.
-  // $GLOBALS['conf']['theme_debug'] = TRUE;
 }
 
 /**
- * Implements HOOK_theme().
+ * Implements hook_theme().
  */
 function STARTERKIT_theme(&$existing, $type, $theme, $path) {
   include_once './' . drupal_get_path('theme', 'STARTERKIT') . '/include/theme-registry.inc';
   return _zen_theme($existing, $type, $theme, $path);
 }
-
 
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
@@ -68,7 +60,7 @@ function STARTERKIT_preprocess_menu_local_tasks(&$variables) {
       $tabs[$key] = array(
         'active' => $variables[$type][$key]['#active'],
         'url' => $variables[$type][$key]['#link']['url']->toString(),
-        'text' => \Drupal\Component\Utility\Html::escape($variables[$type][$key]['#link']['title'])
+        'text' => Html::escape($variables[$type][$key]['#link']['title']),
       );
 
       // Check if the tab should be shown by rendering the original.
@@ -82,133 +74,3 @@ function STARTERKIT_preprocess_menu_local_tasks(&$variables) {
     $variables[$type] = $tabs;
   }
 }
-
-
-/**
- * Override or insert variables into the maintenance page template.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("maintenance_page" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_maintenance_page(&$variables, $hook) {
-  // When a variable is manipulated or added in preprocess_html or
-  // preprocess_page, that same work is probably needed for the maintenance page
-  // as well, so we can just re-use those functions to do that work here.
-  STARTERKIT_preprocess_html($variables, $hook);
-  STARTERKIT_preprocess_page($variables, $hook);
-}
-// */
-
-/**
- * Override or insert variables into the html templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("html" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_html(&$variables, $hook) {
-  $variables['sample_variable'] = t('Lorem ipsum.');
-
-  // The body tag's classes are controlled by the $classes_array variable. To
-  // remove a class from $classes_array, use array_diff().
-  $variables['classes_array'] = array_diff($variables['classes_array'],
-    array('class-to-remove')
-  );
-}
-// */
-
-/**
- * Override or insert variables into the page templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("page" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_page(&$variables, $hook) {
-  $variables['sample_variable'] = t('Lorem ipsum.');
-}
-// */
-
-/**
- * Override or insert variables into the region templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("region" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_region(&$variables, $hook) {
-  // Don't use Zen's region--no-wrapper.tpl.php template for sidebars.
-  if (strpos($variables['region'], 'sidebar_') === 0) {
-    $variables['theme_hook_suggestions'] = array_diff(
-      $variables['theme_hook_suggestions'], array('region__no_wrapper')
-    );
-  }
-}
-// */
-
-/**
- * Override or insert variables into the block templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("block" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_block(&$variables, $hook) {
-  // Add a count to all the blocks in the region.
-  // $variables['classes_array'][] = 'count-' . $variables['block_id'];
-
-  // By default, Zen will use the block--no-wrapper.tpl.php for the main
-  // content. This optional bit of code undoes that:
-  if ($variables['block_html_id'] == 'block-system-main') {
-    $variables['theme_hook_suggestions'] = array_diff(
-      $variables['theme_hook_suggestions'], array('block__no_wrapper')
-    );
-  }
-}
-// */
-
-/**
- * Override or insert variables into the node templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("node" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_node(&$variables, $hook) {
-  $variables['sample_variable'] = t('Lorem ipsum.');
-
-  // Optionally, run node-type-specific preprocess functions, like
-  // STARTERKIT_preprocess_node_page() or STARTERKIT_preprocess_node_story().
-  $function = __FUNCTION__ . '_' . $variables['node']->type;
-  if (function_exists($function)) {
-    $function($variables, $hook);
-  }
-}
-// */
-
-/**
- * Override or insert variables into the comment templates.
- *
- * @param array $variables
- *   Variables to pass to the theme template.
- * @param string $hook
- *   The name of the template being rendered ("comment" in this case.)
- */
-/* -- Delete this line if you want to use this function
-function STARTERKIT_preprocess_comment(&$variables, $hook) {
-  $variables['sample_variable'] = t('Lorem ipsum.');
-}
-// */

--- a/STARTERKIT/components/asset-builds/README.txt
+++ b/STARTERKIT/components/asset-builds/README.txt
@@ -1,12 +1,15 @@
 ZEN'S CSS FILES
 ---------------
 
-All of the files in this folder are files that are generated from the gulp tasks:
+All of the files in this folder are files that are generated from the gulp
+tasks:
   - CSS generated from Sass
   - JavaScript generted from JS source
   - Twig files generated from Sass variables
 
-In older versions of Zen, you could modify the CSS files and ignore the Sass files. But when we converted Zen to using component-based styles, it was clear that it is too hard to write CSS when Drupal makes it hard to change the markup.
+In older versions of Zen, you could modify the CSS files and ignore the Sass
+files. But when we converted Zen to using component-based styles, it was clear
+that it is too hard to write CSS when Drupal makes it hard to change the markup.
 
 You should:
 - ignore these files

--- a/STARTERKIT/components/style-guide/homepage.md
+++ b/STARTERKIT/components/style-guide/homepage.md
@@ -1,31 +1,49 @@
 # Style Guide for the `STARTERKIT` Theme
 
-This style guide documents the designs of this website which are built with component-based styles and Sass variables, functions and mixins. To ensure it is always up-to-date, this style guide is automatically generated from comments in the Sass files.
+This style guide documents the designs of this website which are built
+with component-based styles and Sass variables, functions and mixins.
+To ensure it is always up-to-date, this style guide is automatically
+generated from comments in the Sass files.
 
 ## Organization
 
-Design components are reusable designs that can be applied using just the CSS class names specified in the component. We categorize our components to make them easy to find.
+Design components are reusable designs that can be applied using just
+the CSS class names specified in the component. We categorize our
+components to make them easy to find.
 
 <dl>
 <dt>**Defaults**</dt>
-<dd>`components/base` — The default “base” components apply to HTML elements. Since all of the rulesets in this class of styles are HTML elements, the styles apply automatically.</dd>
+<dd>`components/base` — The default “base” components apply to HTML
+elements. Since all of the rulesets in this class of styles are HTML
+elements, the styles apply automatically.</dd>
 <dt>**Layouts**</dt>
-<dd>`components/layouts` — Layout components position major chunks of the page. They just apply positioning, no other styles.</dd>
+<dd>`components/layouts` — Layout components position major chunks of
+the page. They just apply positioning, no other styles.</dd>
 <dt>**Components**</dt>
-<dd>`components/components` — Miscellaneous components are grouped together, but feel free to further categorize these.</dd>
+<dd>`components/components` — Miscellaneous components are grouped
+together, but feel free to further categorize these.</dd>
 <dt>**Navigation**</dt>
-<dd>`components/navigation` — Navigation components are specialized design components that are applied to website navigation.</dd>
+<dd>`components/navigation` — Navigation components are specialized
+design components that are applied to website navigation.</dd>
 <dt>**Forms**</dt>
-<dd>`components/forms` — Form components are specialized design components that are applied to forms or form elements.</dd>
+<dd>`components/forms` — Form components are specialized design
+components that are applied to forms or form elements.</dd>
 </dl>
 
-In addition to the components, our component library also contains these folders:
+In addition to the components, our component library also contains
+these folders:
 
 <dl>
 <dt>**Colors and Sass**</dt>
-<dd>`components/init` — This Sass documents the colors used throughout the site and various Sass variables, functions and mixins. It also initializes everything we need for all other Sass files: variables, 3rd-party libraries, custom mixins and custom functions.</dd>
+<dd>`components/init` — This Sass documents the colors used throughout
+the site and various Sass variables, functions and mixins. It also
+initializes everything we need for all other Sass files: variables,
+3rd-party libraries, custom mixins and custom functions.</dd>
 <dt>**Style guide helper files**</dt>
-<dd>`components/style-guide` — files needed to build this automated style guide; includes some CSS overrides for the default KSS style guide</dd>
+<dd>`components/style-guide` — files needed to build this automated
+style guide; includes some CSS overrides for the default KSS style
+guide</dd>
 <dt>**Generated files**</dt>
-<dd>`components/asset-builds` — location of the generated CSS; don't alter these files</dd>
+<dd>`components/asset-builds` — location of the generated CSS; don't
+alter these files</dd>
 </dl>

--- a/STARTERKIT/gulpfile.js
+++ b/STARTERKIT/gulpfile.js
@@ -1,3 +1,8 @@
+/**
+ * @file
+ * Script to build the theme.
+ */
+
 /* eslint-env node, es6 */
 /* global Promise */
 /* eslint-disable key-spacing, one-var, no-multi-spaces, max-nested-callbacks, quote-props */
@@ -14,37 +19,33 @@ var importOnce = require('node-sass-import-once'),
 
 var options = {};
 
-// #############################
 // Edit these paths and options.
-// #############################
-
 // The root paths are used to construct all the other paths in this
 // configuration. The "project" root path is where this gulpfile.js is located.
 // While Zen distributes this in the theme root folder, you can also put this
 // (and the package.json) in your project's root folder and edit the paths
 // accordingly.
 options.rootPath = {
-  project     : __dirname + '/',
-  styleGuide  : __dirname + '/styleguide/',
-  theme       : __dirname + '/'
+  project : __dirname + '/',
+  styleGuide : __dirname + '/styleguide/',
+  theme : __dirname + '/'
 };
 
 options.theme = {
-  name       : 'STARTERKIT',
-  root       : options.rootPath.theme,
+  name : 'STARTERKIT',
+  root : options.rootPath.theme,
   components : options.rootPath.theme + 'components/',
-  build      : options.rootPath.theme + 'components/asset-builds/',
-  css        : options.rootPath.theme + 'components/asset-builds/css/',
-  js         : options.rootPath.theme + 'js/',
-  node       : options.rootPath.theme + 'node_modules/'
+  build : options.rootPath.theme + 'components/asset-builds/',
+  css : options.rootPath.theme + 'components/asset-builds/css/',
+  js : options.rootPath.theme + 'js/',
+  node : options.rootPath.theme + 'node_modules/'
 };
 
 // Set the URL used to access the Drupal website under development. This will
 // allow Browser Sync to serve the website and update CSS changes on the fly.
 options.drupalURL = '';
-// options.drupalURL = 'http://localhost';
 
-// Converts module names to absolute paths for easy imports
+// Converts module names to absolute paths for easy imports.
 function sassModuleImporter(url, file, done) {
   try {
     let pathResolution = require.resolve(url);
@@ -72,7 +73,7 @@ options.autoprefixer = {
   ]
 };
 
-// Help KSS to automatically find new component CSS files
+// Help KSS to automatically find new component CSS files.
 var cssFiles = glob.sync('*.css', {cwd: options.theme.css}),
   cssStyleguide = [];
 
@@ -105,7 +106,7 @@ options.styleGuide = {
 
 // Define the paths to the JS files to lint.
 options.eslint = {
-  files  : [
+  files : [
     options.rootPath.project + 'gulpfile.js',
     options.theme.js + '**/*.js',
     '!' + options.theme.js + '**/*.min.js',
@@ -116,33 +117,27 @@ options.eslint = {
 
 // If your files are on a network share, you may want to turn on polling for
 // Gulp watch. Since polling is less efficient, we disable polling by default.
+// Use `options.gulpWatchOptions = {interval: 1000, mode: 'poll'};` as example.
 options.gulpWatchOptions = {};
-// options.gulpWatchOptions = {interval: 1000, mode: 'poll'};
 
-
-// ################################
 // Load Gulp and tools we will use.
-// ################################
-var gulp      = require('gulp'),
-  $           = require('gulp-load-plugins')(),
+// Task gulp-load-plugins will report "undefined" error unless you load
+// gulp-sass manually.
+var gulp = require('gulp'),
+  $ = require('gulp-load-plugins')(),
   browserSync = require('browser-sync').create(),
-  del         = require('del'),
-  // gulp-load-plugins will report "undefined" error unless you load gulp-sass manually.
-  sass        = require('gulp-sass'),
-  kss         = require('kss'),
-  cache       = require('gulp-cached');
+  del = require('del'),
+  sass = require('gulp-sass'),
+  kss = require('kss'),
+  cache = require('gulp-cached');
 
 // The default task.
 gulp.task('default', ['build']);
 
-// #################
 // Build everything.
-// #################
 gulp.task('build', ['styles', 'styleguide', 'lint']);
 
-// ##########
 // Build CSS.
-// ##########
 var sassFiles = [
   options.theme.components + '**/*.scss',
   // Do not open Sass partials as they will be included as needed.
@@ -164,9 +159,7 @@ gulp.task('styles', ['clean:css'], function () {
     .pipe($.if(browserSync.active, browserSync.stream({match: '**/*.css'})));
 });
 
-// ##################
 // Build style guide.
-// ##################
 gulp.task('styleguide', ['clean:styleguide', 'styleguide:kss-example-chroma'], function () {
   return kss(options.styleGuide);
 });
@@ -186,9 +179,7 @@ gulp.task('styleguide:debug', ['clean:styleguide', 'styleguide:kss-example-chrom
   return kss(options.styleGuide);
 });
 
-// #########################
 // Lint Sass and JavaScript.
-// #########################
 gulp.task('lint', ['lint:sass', 'lint:js']);
 
 // Lint JavaScript.
@@ -207,9 +198,7 @@ gulp.task('lint:sass', function () {
     .pipe($.if(isTesting, $.sassLint.failOnError()));
 });
 
-// ##############################
 // Watch for changes and rebuild.
-// ##############################
 gulp.task('watch', ['browser-sync', 'watch:lint-and-styleguide', 'watch:js']);
 
 gulp.task('browser-sync', ['watch:css'], function () {
@@ -237,14 +226,12 @@ gulp.task('watch:js', ['lint:js'], function () {
   return gulp.watch(options.eslint.files, options.gulpWatchOptions, ['lint:js']);
 });
 
-// ######################
 // Clean all directories.
-// ######################
 gulp.task('clean', ['clean:css', 'clean:styleguide']);
 
 // Clean style guide files.
 gulp.task('clean:styleguide', function () {
-  // You can use multiple globbing patterns as you would with `gulp.src`
+  // You can use multiple globbing patterns as you would with `gulp.src`.
   return del([
     options.styleGuide.destination + '*.html',
     options.styleGuide.destination + 'kss-assets',

--- a/STARTERKIT/include/theme-registry.inc
+++ b/STARTERKIT/include/theme-registry.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Contains infrequently used theme registry build functions.
@@ -7,7 +8,7 @@
 use Drupal\Core\Url;
 
 /**
- * Implements HOOK_theme().
+ * Implements hook_theme().
  *
  * We are simply using this hook as a convenient time to do some related work.
  */

--- a/STARTERKIT/js/script.js
+++ b/STARTERKIT/js/script.js
@@ -19,7 +19,6 @@
     attach: function (context, settings) {
 
       // Place your code here.
-
     }
   };
 

--- a/STARTERKIT/theme-settings.php
+++ b/STARTERKIT/theme-settings.php
@@ -1,13 +1,16 @@
 <?php
+
 /**
  * @file
  * Contains the theme's settings form.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_form_system_theme_settings_alter().
  */
-function STARTERKIT_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface &$form_state, $form_id = NULL) {
+function STARTERKIT_form_system_theme_settings_alter(&$form, FormStateInterface &$form_state, $form_id = NULL) {
   // Work-around for a core bug affecting admin themes. See issue #943212.
   if (isset($form_id)) {
     return;


### PR DESCRIPTION
Fix coding standards issues

How to check:
* install fresh drupal
* `cd themes`
* `git clone git@github.com:skilld-labs/zen.git && cd zen && git checkout fix-code-style`
* `drush en components -y`
* `drush en  zen -y`
* `drush zen test_starterkit`
* `drush en test_starterkit -y`
* `drush config-set system.theme default test_starterkit -y` 
* check what theme works correctly and has not errors in dblog reports
* check code using phpcodesniffer
You can use docker container for that

`docker run --rm \
    -v $(pwd):/work \
    skilldlabs/docker-phpcs-drupal phpcs -s --colors \
    --standard=Drupal,DrupalPractice \
    --ignore=*.css,node_modules .`
