### PR TITLE
Fix double escape in tabs

### DIFF
--- a/STARTERKIT/STARTERKIT.theme
+++ b/STARTERKIT/STARTERKIT.theme
@@ -8,7 +8,7 @@
  * @see https://drupal.org/node/1728096
  */
 
-use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\SortArray;
 
 // Auto-rebuild the theme registry during theme development.
 if (theme_get_setting('zen_rebuild_registry') && !defined('MAINTENANCE_MODE')) {
@@ -49,19 +49,19 @@ function STARTERKIT_theme_suggestions_page_alter(array &$suggestions, array $var
  * tabs component.
  */
 function STARTERKIT_preprocess_menu_local_tasks(&$variables) {
-  foreach (array('primary', 'secondary') as $type) {
-    $tabs = array();
+  foreach (['primary', 'secondary'] as $type) {
+    $tabs = [];
 
     // Sort the tabs by #weight.
-    uasort($variables[$type], array('Drupal\Component\Utility\SortArray', 'sortByWeightProperty'));
+    uasort($variables[$type], [SortArray::class, 'sortByWeightProperty']);
 
     foreach (array_keys($variables[$type]) as $key) {
       // Add the tab to a new array.
-      $tabs[$key] = array(
+      $tabs[$key] = [
         'active' => $variables[$type][$key]['#active'],
         'url' => $variables[$type][$key]['#link']['url']->toString(),
-        'text' => Html::escape($variables[$type][$key]['#link']['title']),
-      );
+        'text' => $variables[$type][$key]['#link']['title'],
+      ];
 
       // Check if the tab should be shown by rendering the original.
       $link = drupal_render($variables[$type][$key]);

--- a/STARTERKIT/components/base/root/base-root.twig
+++ b/STARTERKIT/components/base/root/base-root.twig
@@ -14,7 +14,7 @@
 <html {{ html_attributes }}>
   <head>
     {% block head %}
-      <title>{{ title }}</title>
+      <title>{{ title|raw }}</title>
     {% endblock %}
   </head>
   <body {{ attributes }}>

--- a/STARTERKIT/include/theme-registry.inc
+++ b/STARTERKIT/include/theme-registry.inc
@@ -16,7 +16,8 @@ function _zen_theme(&$existing, $type, $theme, $path) {
   // If we are auto-rebuilding the theme registry, warn about the feature.
   $active_theme = \Drupal::theme()->getActiveTheme()->getName();
   $flood_name = $active_theme . '.rebuild_registry_warning';
-  $is_admin_route = \Drupal::service('router.admin_context')->isAdminRoute(\Drupal::routeMatch()->getRouteObject());
+  $is_admin_route = \Drupal::service('router.admin_context')
+    ->isAdminRoute(\Drupal::routeMatch()->getRouteObject());
   if (
     // Don't display on update.php or install.php.
     !defined('MAINTENANCE_MODE')
@@ -28,10 +29,11 @@ function _zen_theme(&$existing, $type, $theme, $path) {
   ) {
     \Drupal::flood()->register($flood_name);
     drupal_set_message(t('For easier theme development, the theme registry is being rebuilt on every page request. It is <em>extremely</em> important to <a href="@link">turn off this feature</a> on production websites.', [
-      '@link' => Url::fromRoute('system.theme_settings_theme', ['theme' => $active_theme])->toString(),
+      '@link' => Url::fromRoute('system.theme_settings_theme', ['theme' => $active_theme])
+        ->toString(),
     ]), 'warning', FALSE);
   }
 
   // hook_theme() expects an array, so return an empty one.
-  return array();
+  return [];
 }

--- a/STARTERKIT/theme-settings.php
+++ b/STARTERKIT/theme-settings.php
@@ -16,14 +16,14 @@ function STARTERKIT_form_system_theme_settings_alter(&$form, FormStateInterface 
     return;
   }
 
-  $form['themedev'] = array(
-    '#type'          => 'fieldset',
-    '#title'         => t('Theme development settings'),
-  );
-  $form['themedev']['zen_rebuild_registry'] = array(
-    '#type'          => 'checkbox',
-    '#title'         => t('Rebuild theme registry and output template debugging on every page.'),
+  $form['themedev'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Theme development settings'),
+  ];
+  $form['themedev']['zen_rebuild_registry'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Rebuild theme registry and output template debugging on every page.'),
     '#default_value' => theme_get_setting('zen_rebuild_registry'),
-    '#description'   => t('During theme development, it can be very useful to continuously <a href="@link">rebuild the theme registry</a> and to output template debugging HTML comments. WARNING: this is a huge performance penalty and must be turned off on production websites.', array('@link' => 'https://drupal.org/node/173880#theme-registry')),
-  );
+    '#description' => t('During theme development, it can be very useful to continuously <a href="@link">rebuild the theme registry</a> and to output template debugging HTML comments. WARNING: this is a huge performance penalty and must be turned off on production websites.', ['@link' => 'https://drupal.org/node/173880#theme-registry']),
+  ];
 }


### PR DESCRIPTION
- Also fix double escape of title https://www.drupal.org/node/2833767
- convert to short array syntax

Closes #29