### PR TITLE
Linters should always run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build lint
+
+CUID = $(shell id -u)
+CGID = $(shell id -g)
+
+IMAGE_FRONT := skilldlabs/frontend:zen
+NODE_ENV ?= testing
+front = docker run --rm -u $(CUID):$(CGID) -v $(shell pwd)/STARTERKIT:/work -e NODE_ENV=$(NODE_ENV) $(IMAGE_FRONT) ${1}
+
+all: | build
+
+build:
+	@echo "Running build tasks..."
+	docker pull $(IMAGE_FRONT)
+	$(call front)
+
+lint:
+	@echo "Running linters..."
+	$(call front, gulp lint)

--- a/STARTERKIT/README.txt
+++ b/STARTERKIT/README.txt
@@ -183,22 +183,21 @@ Set up your front-end development build tools:
 
       gulp watch
 
+    To lint CSS & JS run `gulp lint`
+
     To better understand the recommended development process for your Zen
     sub-theme, watch the Drupalcon presentation, "Style Guide Driven
     Development: All hail the robot overlords!"
     https://youtu.be/y5coJloNutU
 
  6. The environment can be adjusted by using the NODE_ENV variable, the
-    available environments are 'production', 'testing' and 'development'.
+    available environments are 'production' and 'testing'.
     This last one is the default.
 
       # production: for minified assets
       NODE_ENV=production gulp
 
-      # testing: linters will change exit error code if they fail
-      NODE_ENV=testing gulp linters
-
-      # default/development
+      # default/testing
       gulp
 
 Optional steps:

--- a/STARTERKIT/gulpfile.js
+++ b/STARTERKIT/gulpfile.js
@@ -6,16 +6,15 @@
 /* eslint-env node, es6 */
 /* global Promise */
 /* eslint-disable key-spacing, one-var, no-multi-spaces, max-nested-callbacks, quote-props */
+/* eslint strict: ["error", "global"] */
 
 'use strict';
-
 
 var importOnce = require('node-sass-import-once'),
   path = require('path'),
   glob = require('glob'),
-  env = process.env.NODE_ENV || 'development',
-  isProduction = (env === 'production'),
-  isTesting = (env === 'testing');
+  env = process.env.NODE_ENV || 'testing',
+  isProduction = (env === 'production');
 
 var options = {};
 
@@ -187,7 +186,7 @@ gulp.task('lint:js', function () {
   return gulp.src(options.eslint.files)
     .pipe($.eslint())
     .pipe($.eslint.format())
-    .pipe($.if(isTesting, $.eslint.failOnError()));
+    .pipe($.eslint.failOnError());
 });
 
 // Lint Sass.
@@ -195,7 +194,7 @@ gulp.task('lint:sass', function () {
   return gulp.src(options.theme.components + '**/*.scss')
     .pipe($.sassLint())
     .pipe($.sassLint.format())
-    .pipe($.if(isTesting, $.sassLint.failOnError()));
+    .pipe($.sassLint.failOnError());
 });
 
 // Watch for changes and rebuild.


### PR DESCRIPTION
- Production supposed to pass linting always
- Add `Makefile` to simplify testing and show example of usage with docker